### PR TITLE
Fixed Bug in Notifications

### DIFF
--- a/code/background.js
+++ b/code/background.js
@@ -45,15 +45,16 @@ bg.setRunningCall = () => {
         if (result.break_audio === undefined) {
           breakAudio.play();
           chrome.storage.local.set({'break_audio': 'on'});
+          chrome.notifications.clear('focus_end');
           chrome.notifications.create('focus_end', {
             title: 'Your focus session is over',
             message: 'Time to take a break!',
             iconUrl: chrome.extension.getURL('img/logo.jpg'),
             type: 'basic',
           });
-          chrome.notifications.clear('break_end');
         } else if (result.break_audio === 'on') {
           breakAudio.play();
+          chrome.notifications.clear('focus_end');
           chrome.notifications.create('focus_end', {
             title: 'Your focus session is over',
             message: 'Time to take a break!',
@@ -69,6 +70,7 @@ bg.setRunningCall = () => {
       chrome.storage.local.get(['focus_audio'], function(result) {
         if (result.focus_audio === undefined) {
           focusAudio.play();
+          chrome.notifications.clear('break_end');
           chrome.storage.local.set({'focus_audio': 'on'});
           chrome.notifications.create('break_end', {
             title: 'Your break is over',
@@ -76,16 +78,15 @@ bg.setRunningCall = () => {
             iconUrl: chrome.extension.getURL('img/logo.jpg'),
             type: 'basic',
           });
-          chrome.notifications.clear('focus_end');
         } else if (result.focus_audio === 'on') {
           focusAudio.play();
+          chrome.notifications.clear('break_end');
           chrome.notifications.create('break_end', {
             title: 'Your break is over',
             message: 'Time to get back to work!',
             iconUrl: chrome.extension.getURL('img/logo.jpg'),
             type: 'basic',
           });
-          chrome.notifications.clear('focus_end');
         }
       });
       audioPlayed = 'focus'; // for testing


### PR DESCRIPTION
The visual notifications were not clearing itself at the right time, so there was a bug when only one notification was checked, but it's fixed now! When only one notification is checked, it will still show the visual notifications

Test Plan:
- Manually tested all four scenarios (when both are checked, when either one is checked, and when none are checked)